### PR TITLE
Remove exception message checking

### DIFF
--- a/sql/src/main/java/com/coditory/sherlock/SqlDistributedLockConnector.java
+++ b/sql/src/main/java/com/coditory/sherlock/SqlDistributedLockConnector.java
@@ -114,9 +114,6 @@ class SqlDistributedLockConnector implements DistributedLockConnector {
             setupOptionalTimestamp(statement, 4, expiresAt);
             return statement.executeUpdate() > 0;
         } catch (SQLException e) {
-            if (!e.getMessage().toLowerCase().contains("duplicate")) {
-                throw e;
-            }
             return false;
         }
     }


### PR DESCRIPTION
Fixes #99

The code checked the exception message to distinguish lockId duplication from other exceptions.
We can safely remove the check and return `false` for all exception types.